### PR TITLE
feat: :sparkles: add image avatars as an option

### DIFF
--- a/src/app/components/chips-select/chips-select.component.html
+++ b/src/app/components/chips-select/chips-select.component.html
@@ -1,9 +1,16 @@
 <form>
   <mat-form-field class="example-chip-list" class="{{ class }}">
-    <mat-label @if(customLabel)>{{ customLabel }}</mat-label>
+    @if(customLabel){<mat-label>{{ customLabel }}</mat-label
+    >}
     <mat-chip-grid #chipGrid aria-label="object selection ">
       @for (object of selectedObjects; track object) {
       <mat-chip-row (removed)="remove(object)">
+        @if(isViewImage(object)){
+          <img
+            matChipAvatar
+            [src]="object[imagePropertyName]"
+          />}
+
         {{ object[searchPropertyName] }}
         <button
           matChipRemove

--- a/src/app/components/chips-select/chips-select.component.ts
+++ b/src/app/components/chips-select/chips-select.component.ts
@@ -21,6 +21,7 @@ import { AsyncPipe } from '@angular/common';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { URL_REGEX } from '../../shared/const';
 /**
  * @title Chips Autocomplete
  */
@@ -44,6 +45,7 @@ export class ShipsSelectComponent {
   @Input() ObjectName!: string;
   @Input() customLabel!: string;
   @Input() searchPropertyName: string = 'label';
+  @Input() imagePropertyName: string = ''; // optional : add the property name of the image
   @Input() minimumSearchLength: number = 2;
   @Input() minimumAddedLabelLength: number = 5;
   @Input() class: string = '';
@@ -83,6 +85,7 @@ export class ShipsSelectComponent {
       }
     );
     this._verifySearchPropertyName();
+    this._verifyImagePropertyName();
   }
 
   ngOnDestroy() {
@@ -179,6 +182,21 @@ export class ShipsSelectComponent {
     this._isAdditionEnabled = isAdditionEnabled;
   }
 
+  isViewImage(chipObject: any): boolean {
+    if (this.imagePropertyName === '') return false;
+    if (this.imagePropertyName === undefined) return false;
+    if (this.imagePropertyName === null) return false;
+    let imageUrl = '';
+    try {
+      imageUrl = chipObject[this.imagePropertyName];
+    } catch (error) {
+      imageUrl = '';
+    }
+    if (imageUrl == '' || typeof imageUrl != 'string') return false;
+    const isValidUrl = URL_REGEX.test(imageUrl);
+    return isValidUrl;
+  }
+
   private _addChipToSelection(newChip: any, isAdded = false): void {
     this.selectedObjects.push(newChip);
     this.ObjectControl.setValue(null);
@@ -216,21 +234,61 @@ export class ShipsSelectComponent {
     if (!this.fullData || this.fullData.length == 0) return;
     if (!this.fullData[0].hasOwnProperty(this.searchPropertyName)) {
       throw new TypeError(
-        'chip select: ' +
-          this.customLabel +
+        'Chip select component : ' +
           " the provided data doesn't contain the searchPropertyName : " +
-          this.searchPropertyName
+          this.searchPropertyName +
+          ' || Component Label : ' +
+          this.customLabel
       );
     }
     let searchablePropertyType =
       typeof this.fullData[0][this.searchPropertyName];
-    if (!(searchablePropertyType in ['number', 'string'])) {
+    if (['number', 'string'].includes(searchablePropertyType) == false) {
       throw new TypeError(
-        'chip select: ' +
-          this.customLabel +
-          ' the provided searchPropertyName ( ' +
+        'Chip select component : ' +
+          'the provided searchPropertyName ( ' +
           this.searchPropertyName +
-          " ) isn't of type String Or Number"
+          " ) isn't of type String Or Number" +
+          ' || Component Label : ' +
+          this.customLabel
+      );
+    }
+  }
+
+  private _verifyImagePropertyName(): void {
+    if (!this.fullData || this.fullData.length == 0) return;
+    if (this.imagePropertyName === '' || this.imagePropertyName === undefined)
+      return;
+    if (!this.fullData[0].hasOwnProperty(this.imagePropertyName)) {
+      throw new TypeError(
+        'Chip select component : ' +
+          " the provided data doesn't contain the image property name : " +
+          this.imagePropertyName +
+          ' || Component Label : ' +
+          this.customLabel
+      );
+    }
+    let imagePropertyType = typeof this.fullData[0][this.imagePropertyName];
+    if (imagePropertyType != 'string') {
+      throw new TypeError(
+        'Chip select component : ' +
+          'the provided ImagePropertyName ( ' +
+          this.imagePropertyName +
+          " ) isn't of type String (must be a url)" +
+          ' || Component Label : ' +
+          this.customLabel
+      );
+    }
+    let imageUrl = this.fullData[0][this.imagePropertyName];
+    const isValidUrl = URL_REGEX.test(imageUrl);
+    if (!isValidUrl) {
+      throw new TypeError(
+        'Chip select component : ' +
+          'the provided ImagePropertyName ( ' +
+          this.imagePropertyName +
+          " ) isn't a valid url" +
+          ' || Component Label : ' +
+          this.customLabel
       );
     }
   }
@@ -279,5 +337,6 @@ export type onChipsSelectionEmitType = {
       [minimumAddedLabelLength]="5"
       [isStartWithSearch]="true"
       [searchPropertyName]="'label'"
+      [imagePropertyName]="''"
     ></chips-select>
 */

--- a/src/app/shared/const.ts
+++ b/src/app/shared/const.ts
@@ -1,0 +1,1 @@
+export const URL_REGEX = /^(ftp|http|https):\/\/[^ "]+$/;


### PR DESCRIPTION
Added an optional image avatar, which can be mapped by entering its property name.
 Also the component will handle the cases where part of data doesnt have this image (as shown in the screenshot below).
 
![image](https://github.com/MedicalSecure/MedSecure-fe/assets/97397110/da39e218-6f21-4ef2-adb4-4331ab14bb57)
